### PR TITLE
refactor: :recycle: Removendo os comandos de migrate

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-dev.yml
+++ b/{{cookiecutter.project_slug}}/docker-dev.yml
@@ -56,7 +56,7 @@ services:
       dockerfile: ./DockerfileDev
     networks:
       - {{cookiecutter.project_slug.lower()}}_network
-    command: bash -c "python manage.py makemigrations; python manage.py migrate; python manage.py collectstatic; python manage.py runserver 0.0.0.0:8000;"
+    command: bash -c "python manage.py collectstatic; python manage.py runserver 0.0.0.0:8000;"
     volumes:
       - .:/app
       - ../../FastAPI/{{cookiecutter.project_slug.lower()}}:/FastAPI


### PR DESCRIPTION
Removendo os comandos de migração do arquivo docker-dev.yaml para agilizar a criação do container